### PR TITLE
Mark test libraries as test scope

### DIFF
--- a/extensions/adwords_rate_limiter/pom.xml
+++ b/extensions/adwords_rate_limiter/pom.xml
@@ -30,11 +30,13 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <version>1.8.5</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
The "junit" and "mockito" libraries in the `adwords_rate_limiter` are not currently marked as `test` scope. This causes trouble for projects which wish to include this library but which use different versions of these libs or which don't need these libs.

I have checked that `mvn test` passes after this change.