### PR TITLE
Google.inject API

### DIFF
--- a/modules/ads_lib/src/main/java/com/google/api/ads/admanager/lib/client/AdManagerServiceClient.java
+++ b/modules/ads_lib/src/main/java/com/google/api/ads/admanager/lib/client/AdManagerServiceClient.java
@@ -20,7 +20,7 @@ import com.google.api.ads.common.lib.soap.SoapClientHandlerInterface;
 import com.google.api.ads.common.lib.soap.SoapServiceClient;
 import com.google.api.ads.common.lib.utils.logging.AdsServiceLoggers;
 import com.google.inject.assistedinject.Assisted;
-import javax.inject.Inject;
+import com.google.inject.Inject;
 
 /**
  * Wrapper of underlying SOAP client which allows access for setting headers retrieved from the

--- a/modules/ads_lib/src/main/java/com/google/api/ads/admanager/lib/client/AdManagerServiceDescriptor.java
+++ b/modules/ads_lib/src/main/java/com/google/api/ads/admanager/lib/client/AdManagerServiceDescriptor.java
@@ -22,7 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.assistedinject.Assisted;
 import java.net.MalformedURLException;
 import java.net.URL;
-import javax.inject.Inject;
+import com.google.inject.Inject;
 
 /**
  * {@code AdManagerServiceDescriptor} provides a class which defines a service that can be

--- a/modules/ads_lib/src/main/java/com/google/api/ads/admanager/lib/conf/AdManagerApiConfiguration.java
+++ b/modules/ads_lib/src/main/java/com/google/api/ads/admanager/lib/conf/AdManagerApiConfiguration.java
@@ -16,7 +16,7 @@ package com.google.api.ads.admanager.lib.conf;
 
 import com.google.api.ads.common.lib.conf.AdsApiConfiguration;
 import com.google.inject.name.Named;
-import javax.inject.Inject;
+import com.google.inject.Inject;
 import org.apache.commons.configuration.Configuration;
 
 /** Configuration information for Ad Manager library. */

--- a/modules/ads_lib/src/main/java/com/google/api/ads/admanager/lib/conf/AdManagerLibConfiguration.java
+++ b/modules/ads_lib/src/main/java/com/google/api/ads/admanager/lib/conf/AdManagerLibConfiguration.java
@@ -16,7 +16,7 @@ package com.google.api.ads.admanager.lib.conf;
 
 import com.google.api.ads.common.lib.conf.AdsLibConfiguration;
 import com.google.inject.name.Named;
-import javax.inject.Inject;
+import com.google.inject.Inject;
 import org.apache.commons.configuration.Configuration;
 
 /** Configuration information for Ad Manager library. */

--- a/modules/ads_lib/src/main/java/com/google/api/ads/admanager/lib/factory/AdManagerServiceClientFactory.java
+++ b/modules/ads_lib/src/main/java/com/google/api/ads/admanager/lib/factory/AdManagerServiceClientFactory.java
@@ -22,7 +22,7 @@ import com.google.api.ads.common.lib.factory.BaseAdsServiceClientFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
-import javax.inject.Inject;
+import com.google.inject.Inject;
 
 /** Factory which creates Ad Manager service clients. */
 public class AdManagerServiceClientFactory

--- a/modules/ads_lib/src/main/java/com/google/api/ads/admanager/lib/factory/helper/AdManagerServiceClientFactoryHelper.java
+++ b/modules/ads_lib/src/main/java/com/google/api/ads/admanager/lib/factory/helper/AdManagerServiceClientFactoryHelper.java
@@ -25,7 +25,7 @@ import com.google.api.ads.common.lib.factory.helper.BaseAdsServiceClientFactoryH
 import com.google.api.ads.common.lib.soap.SoapClientHandlerInterface;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import javax.inject.Inject;
+import com.google.inject.Inject;
 
 /** Factory helper for Ad Manager. */
 public class AdManagerServiceClientFactoryHelper

--- a/modules/ads_lib/src/main/java/com/google/api/ads/admanager/lib/soap/AdManagerHttpHeaderHandler.java
+++ b/modules/ads_lib/src/main/java/com/google/api/ads/admanager/lib/soap/AdManagerHttpHeaderHandler.java
@@ -18,7 +18,7 @@ import com.google.api.ads.admanager.lib.client.AdManagerSession;
 import com.google.api.ads.common.lib.soap.SoapClientHandlerInterface;
 import com.google.common.collect.Maps;
 import java.util.Map;
-import javax.inject.Inject;
+import com.google.inject.Inject;
 
 /** Handler used to set the HTTP headers on a SOAP client. */
 public class AdManagerHttpHeaderHandler {

--- a/modules/ads_lib/src/main/java/com/google/api/ads/common/lib/auth/AuthorizationHeaderProvider.java
+++ b/modules/ads_lib/src/main/java/com/google/api/ads/common/lib/auth/AuthorizationHeaderProvider.java
@@ -23,7 +23,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 
 import javax.annotation.Nullable;
-import javax.inject.Inject;
+import com.google.inject.Inject;
 
 /**
  * Authorization header provider that can delegate between different

--- a/modules/ads_lib/src/main/java/com/google/api/ads/common/lib/auth/OAuth2Helper.java
+++ b/modules/ads_lib/src/main/java/com/google/api/ads/common/lib/auth/OAuth2Helper.java
@@ -22,7 +22,7 @@ import org.slf4j.Logger;
 
 import java.io.IOException;
 
-import javax.inject.Inject;
+import com.google.inject.Inject;
 
 /**
  * OAuth2 helper functions.

--- a/modules/ads_lib/src/main/java/com/google/api/ads/common/lib/conf/AdsBuildConfiguration.java
+++ b/modules/ads_lib/src/main/java/com/google/api/ads/common/lib/conf/AdsBuildConfiguration.java
@@ -18,7 +18,7 @@ import com.google.inject.name.Named;
 
 import org.apache.commons.configuration.Configuration;
 
-import javax.inject.Inject;
+import com.google.inject.Inject;
 
 /**
  * Configuration of lib properties.

--- a/modules/ads_lib/src/main/java/com/google/api/ads/common/lib/conf/ProductConfiguration.java
+++ b/modules/ads_lib/src/main/java/com/google/api/ads/common/lib/conf/ProductConfiguration.java
@@ -18,7 +18,7 @@ import com.google.inject.name.Named;
 
 import org.apache.commons.configuration.Configuration;
 
-import javax.inject.Inject;
+import com.google.inject.Inject;
 
 /**
  * Configuration of product/framework properties.

--- a/modules/ads_lib/src/main/java/com/google/api/ads/common/lib/conf/ProductFrameworkConfiguration.java
+++ b/modules/ads_lib/src/main/java/com/google/api/ads/common/lib/conf/ProductFrameworkConfiguration.java
@@ -18,7 +18,7 @@ import com.google.inject.name.Named;
 
 import org.apache.commons.configuration.Configuration;
 
-import javax.inject.Inject;
+import com.google.inject.Inject;
 
 /**
  * Configuration of product/framework properties.

--- a/modules/ads_lib/src/main/java/com/google/api/ads/common/lib/factory/AdsServiceClientFactory.java
+++ b/modules/ads_lib/src/main/java/com/google/api/ads/common/lib/factory/AdsServiceClientFactory.java
@@ -24,7 +24,7 @@ import com.google.common.collect.Sets;
 import java.lang.reflect.Proxy;
 import java.util.Set;
 
-import javax.inject.Inject;
+import com.google.inject.Inject;
 
 /**
  * Factory which creates ads service clients.

--- a/modules/ads_lib/src/main/java/com/google/api/ads/common/lib/soap/AuthorizationHeaderHandler.java
+++ b/modules/ads_lib/src/main/java/com/google/api/ads/common/lib/soap/AuthorizationHeaderHandler.java
@@ -20,7 +20,7 @@ import com.google.api.ads.common.lib.exception.AuthenticationException;
 
 import java.util.HashMap;
 
-import javax.inject.Inject;
+import com.google.inject.Inject;
 
 /**
  * Handler for {@code Authorization} headers that can be set on the SOAP

--- a/modules/ads_lib/src/main/java/com/google/api/ads/common/lib/useragent/AdsLibraryUserAgentProvider.java
+++ b/modules/ads_lib/src/main/java/com/google/api/ads/common/lib/useragent/AdsLibraryUserAgentProvider.java
@@ -16,7 +16,7 @@ package com.google.api.ads.common.lib.useragent;
 
 import com.google.api.ads.common.lib.conf.AdsBuildConfiguration;
 
-import javax.inject.Inject;
+import com.google.inject.Inject;
 
 /**
  * Provides the ads library user agent.

--- a/modules/ads_lib/src/main/java/com/google/api/ads/common/lib/useragent/BuildTypeUserAgentProvider.java
+++ b/modules/ads_lib/src/main/java/com/google/api/ads/common/lib/useragent/BuildTypeUserAgentProvider.java
@@ -16,7 +16,7 @@ package com.google.api.ads.common.lib.useragent;
 
 import com.google.api.ads.common.lib.conf.AdsBuildConfiguration;
 
-import javax.inject.Inject;
+import com.google.inject.Inject;
 
 /**
  * Provides the build type user agent.

--- a/modules/ads_lib/src/main/java/com/google/api/ads/common/lib/useragent/ProductFrameworkUserAgentProvider.java
+++ b/modules/ads_lib/src/main/java/com/google/api/ads/common/lib/useragent/ProductFrameworkUserAgentProvider.java
@@ -16,7 +16,7 @@ package com.google.api.ads.common.lib.useragent;
 
 import com.google.api.ads.common.lib.conf.ProductFrameworkConfiguration;
 
-import javax.inject.Inject;
+import com.google.inject.Inject;
 
 /**
  * Provides product/framework user agent.

--- a/modules/ads_lib/src/main/java/com/google/api/ads/common/lib/useragent/ProductUserAgentProvider.java
+++ b/modules/ads_lib/src/main/java/com/google/api/ads/common/lib/useragent/ProductUserAgentProvider.java
@@ -16,7 +16,7 @@ package com.google.api.ads.common.lib.useragent;
 
 import com.google.api.ads.common.lib.conf.ProductConfiguration;
 
-import javax.inject.Inject;
+import com.google.inject.Inject;
 
 /**
  * Provides product user agent.

--- a/modules/ads_lib/src/main/java/com/google/api/ads/common/lib/utils/Internals.java
+++ b/modules/ads_lib/src/main/java/com/google/api/ads/common/lib/utils/Internals.java
@@ -20,7 +20,7 @@ import com.google.api.ads.common.lib.useragent.UserAgentCombiner;
 import com.google.api.ads.common.lib.utils.logging.AdsServiceLoggers;
 import com.google.api.client.http.HttpTransport;
 
-import javax.inject.Inject;
+import com.google.inject.Inject;
 
 /**
  * Provides access to internal utilities.

--- a/modules/ads_lib/src/main/java/com/google/api/ads/common/lib/utils/logging/AdsServiceLoggers.java
+++ b/modules/ads_lib/src/main/java/com/google/api/ads/common/lib/utils/logging/AdsServiceLoggers.java
@@ -17,7 +17,7 @@ package com.google.api.ads.common.lib.utils.logging;
 import com.google.api.ads.common.lib.client.RemoteCallReturn;
 import com.google.api.ads.common.lib.utils.logging.RemoteCallLoggerDelegate.RemoteCallType;
 import com.google.inject.name.Named;
-import javax.inject.Inject;
+import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/modules/ads_lib_axis/src/main/java/com/google/api/ads/common/lib/soap/axis/AxisFrameworkUserAgentProvider.java
+++ b/modules/ads_lib_axis/src/main/java/com/google/api/ads/common/lib/soap/axis/AxisFrameworkUserAgentProvider.java
@@ -19,7 +19,7 @@ import com.google.inject.name.Named;
 
 import org.apache.commons.configuration.Configuration;
 
-import javax.inject.Inject;
+import com.google.inject.Inject;
 
 /**
  * Provides the Axis user agent.

--- a/modules/ads_lib_axis/src/main/java/com/google/api/ads/common/lib/soap/axis/AxisHandler.java
+++ b/modules/ads_lib_axis/src/main/java/com/google/api/ads/common/lib/soap/axis/AxisHandler.java
@@ -29,7 +29,7 @@ import com.google.common.base.Preconditions;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Hashtable;
 import java.util.Map;
-import javax.inject.Inject;
+import com.google.inject.Inject;
 import javax.xml.namespace.QName;
 import javax.xml.soap.SOAPException;
 import org.apache.axis.EngineConfiguration;

--- a/modules/ads_lib_axis/src/main/java/com/google/api/ads/common/lib/soap/axis/conf/AdsAxisEngineConfigurationFactory.java
+++ b/modules/ads_lib_axis/src/main/java/com/google/api/ads/common/lib/soap/axis/conf/AdsAxisEngineConfigurationFactory.java
@@ -15,7 +15,7 @@
 package com.google.api.ads.common.lib.soap.axis.conf;
 
 import com.google.api.ads.common.lib.conf.AdsLibConfiguration;
-import javax.inject.Inject;
+import com.google.inject.Inject;
 import org.apache.axis.EngineConfiguration;
 import org.apache.axis.EngineConfigurationFactory;
 import org.apache.axis.configuration.EngineConfigurationFactoryDefault;

--- a/modules/dfp_axis/src/main/java/com/google/api/ads/admanager/axis/AdManagerAxisHeaderHandler.java
+++ b/modules/dfp_axis/src/main/java/com/google/api/ads/admanager/axis/AdManagerAxisHeaderHandler.java
@@ -27,7 +27,7 @@ import com.google.api.ads.common.lib.soap.axis.AxisHandler;
 import com.google.api.ads.common.lib.useragent.UserAgentCombiner;
 import com.google.common.base.Preconditions;
 import java.lang.reflect.InvocationTargetException;
-import javax.inject.Inject;
+import com.google.inject.Inject;
 import org.apache.axis.client.Stub;
 import org.apache.commons.beanutils.BeanUtils;
 


### PR DESCRIPTION
Use google.inject annotation instead of javax.inject. It allows users to use different version of guice in their project, because guice 7.0.0 is supporting jakarta API or google.inject, and 5.0.1 version is working with javax.inject and google.inject. All versions support google.inject annotations